### PR TITLE
Fix typo on court research blog post

### DIFF
--- a/posts/2024/04/29/court-systems-research.mdx
+++ b/posts/2024/04/29/court-systems-research.mdx
@@ -20,7 +20,7 @@ Across 16 interviews and more than 10 hours of conversation, four themes emerged
 
 - **Filer fees heavily subsidize filing systems, and that's hard on self-represented litigants.** Courts don't pay for most filing systems; the people courts serve do. Litigants have to "pay to play," and that creates an additional barrier for many self-represented applicants. Applying for a fee waiver often forces busy litigants through another set of hoops. Many of our interviewees yearned for new business models for eFiling systems that don't depend on user fees.
 
-- **Courts pay big to make small changes to systems that might help people.** Many courts and filer advocates want to change the text, flow or other details of their eFiling or case management system so it is clearer for everyone. But after the system is implemented, these changes are often very expensive. Sometimes, they even require new contracts. Even when a simple change could prevent filer mistakes, and save court timer, it often never happens.
+- **Courts pay big to make small changes to systems that might help people.** Many courts and filer advocates want to change the text, flow or other details of their eFiling or case management system so it is clearer for everyone. But after the system is implemented, these changes are often very expensive. Sometimes, they even require new contracts. Even when a simple change could prevent filer mistakes, and save the court time, it often never happens.
 
 These are just a few of the findings in our first report on this topic. To learn more, including a detailed overview of the way these systems fit together, read our full report.
 


### PR DESCRIPTION
Change "save court timer" to "save the court time"