### PR TITLE
fix(homepage): Fix filepath to correct svgs for smaller devices

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -46,7 +46,7 @@ export default function Home({ allPostsData }) {
               />
             </div>
             <div className="flex sm:hidden justify-end w-1/3 pl-4 relative h-24">
-              <Image src="/images/icons/medium-color.svg" alt="The RECAP logo" layout="fill" />
+              <Image src="/images/icons/medium-color-recap.svg" alt="The RECAP logo" layout="fill" />
             </div>
             <div
               className="grid grid-cols-1 sm:grid-cols-3 w-full gap-6 sm:gap-8"
@@ -153,7 +153,7 @@ export default function Home({ allPostsData }) {
             </div>
             <div className="flex sm:hidden justify-end w-1/3 pl-4 relative h-24">
               <Image
-                src="/images/icons/medicum-color-cl.svg"
+                src="/images/icons/medium-color-cl.svg"
                 alt="The CourtListener logo"
                 layout="fill"
               />


### PR DESCRIPTION
Fix images see below for fixes.


<img width="422" alt="Screenshot 2024-07-09 at 2 32 34 PM" src="https://github.com/freelawproject/free.law/assets/6464529/0a050030-826e-46dd-800f-203dca1948b3">
<img width="444" alt="Screenshot 2024-07-09 at 2 32 30 PM" src="https://github.com/freelawproject/free.law/assets/6464529/9deff105-7b22-43d3-a3b2-f7393f04476d">
