### PR TITLE
feat(recap): Adds new button to the RECAP page.

### DIFF
--- a/posts/recap.mdx
+++ b/posts/recap.mdx
@@ -9,14 +9,23 @@ imagePath: "/images/banners/recap.png"
 
 If you use PACER, consider installing the RECAP extension in your browser. If you are a researcher, you can search millions of federal filings in the <a href="https://www.courtlistener.com/recap/">RECAP Archive</a>. Journalists and court watchers will find <a href="/2023/03/13/what-is-in-the-recap-suite/">docket alerts</a> invaluable. If you get notifications from PACER, check out <a href="/help/recap/email/">our NEF notification handler</a>.
 
-<div className="flex flex-wrap gap-2 justify-center">
-    <PurpleButton size="lg" href="https://chrome.google.com/webstore/detail/recap/oiillickanjlaeghobeeknbddaonmjnc" extraClasses="inline-flex"><DownloadIcon className="flex-shrink-0 h-5 w-4" aria-hidden="true"/>&nbsp;Add to Chrome or Edge</PurpleButton>
-    <span className="pt-4 hidden sm:inline">&nbsp;</span>
+<div className="grid grid-cols-4 gap-x-1 gap-y-2 justify-center">
+  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
+    <PurpleButton size="lg" href="https://chrome.google.com/webstore/detail/recap/oiillickanjlaeghobeeknbddaonmjnc" 
+                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Chrome</PurpleButton>
+  </div>
+  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
+    <PurpleButton size="lg" href="https://microsoftedge.microsoft.com/addons/detail/ckkpjgceaenndjdjpbaoaociikjpfdjg" 
+                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Edge</PurpleButton> 
+  </div>
+  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
     <PurpleButton size="lg" href="https://apps.apple.com/us/app/recap/id1600281788"
-                  extraClasses="inline-flex"><DownloadIcon className="flex-shrink-0 h-5 w-4" aria-hidden="true"/>&nbsp;Add to Safari&nbsp;</PurpleButton>
-    <span className="pt-4 hidden sm:inline">&nbsp;</span>
+                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Safari&nbsp;</PurpleButton>
+  </div>
+  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
     <PurpleButton size="lg" href="https://addons.mozilla.org/en-US/firefox/addon/recap-195534/"
-                  extraClasses="inline-flex"><DownloadIcon className="flex-shrink-0 h-5 w-4" aria-hidden="true"/>&nbsp;Add to Firefox&nbsp;</PurpleButton>
+                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Firefox&nbsp;</PurpleButton>
+  </div>
 </div>
 <br/>
 


### PR DESCRIPTION
This commit adds a new button on the recap page that links users directly to the Microsoft Edge store to download the extension.  With a single click, users can be directed to the official extension store within Microsoft Edge

Here are screenshots of the page for different screen resolutions:. 

- Small-Medium Resolutions: 

![image](https://github.com/user-attachments/assets/1266f72b-7ee5-4db3-b18d-6f46646d72df)


- Large Resolutions: 

![image](https://github.com/user-attachments/assets/294c1d65-58f5-4934-9ce3-a8f7b03e7697)
