### PR TITLE
feat(posts): add 2024 RECAP EOY fundraising page

### DIFF
--- a/posts/fundraiser/2024/recap.mdx
+++ b/posts/fundraiser/2024/recap.mdx
@@ -1,0 +1,30 @@
+---
+title: Sorry for the Interruption, but RECAP and Free Law Project Need Your Support.
+type: page
+---
+
+<SimpleDisclosure buttonText={"Where did this tab come from?"}>
+  <p>You use the RECAP extension. RECAP is maintained by Free Law Project, a small non-profit that works to improve the American judicial system.</p>
+  <p>Maintaining RECAP is difficult and expensive and we sometimes pop open a tab like this to ask for your support.</p>
+  <p>If RECAP has saved you time or money or if you believe in the work we do, we hope you will support us.</p>
+  <p>Sorry to interrupt you.</p>
+</SimpleDisclosure>
+
+
+<p className="lead">The RECAP extension you have installed is maintained by Free Law Project, a non-profit that works to improve the justice system. This is our website. Once each year we ask for donations so we can continue hosting and enhancing RECAP.</p>
+<p className="lead">The more support you give, the more we are able to do.</p>
+
+We need your support to continue enhancing and maintaining the RECAP system. If RECAP has saved you money or if you believe in what we do, please help us with a tax-deductible donation today.
+
+[//]: # (TODO: Once the 2024 letter is published, uncomment lines 21-26 and remove lines 28-30)
+
+[//]: # (To learn more about our work in 2024, please read our director's annual letter.)
+
+[//]: # (<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">)
+[//]: # (  <WhiteButton href="/fundraiser/2024/" size="lg">Read Our Letter</WhiteButton>)
+[//]: # (  <RedButton href="https://donate.free.law/forms/supportflp" size="lg">Donate Now</RedButton>)
+[//]: # (</div>)
+
+<div className="flex w-full justify-center">
+  <RedButton href="https://donate.free.law/forms/supportflp" size="lg">Donate Now</RedButton>
+</div>


### PR DESCRIPTION
Closes #233

The updated code for when the 2024 director's letter is ready is added in this PR as comments, so when that's ready we can just uncomment them.

Currently looks like this:
![image](https://github.com/user-attachments/assets/fde0c99d-4604-4fa6-a8dc-ebb19bf62fc8)
