### PR TITLE
fix(EOY_dialog): prevent first dialog from appearing after its end date.

### DIFF
--- a/components/dialog.js
+++ b/components/dialog.js
@@ -75,7 +75,7 @@ export function EOYDialog() {
     const secondEOYDialogDismissalDate = localStorage.getItem('secondEOYDialogDismissalDate');
     const secondDismissed = dismissedWithinWeek(secondEOYDialogDismissalDate);
 
-    if (!firstDismissed && dialogStart <= today <= firstDialogEnd) {
+    if (!firstDismissed && dialogStart <= today && today <= firstDialogEnd) {
       setDialogVersion('first');
       setIsOpen(true);
     } else if (!secondDismissed && firstDialogEnd <= today && today <= secondDialogEnd) {


### PR DESCRIPTION
I noticed the first dialog was still showing up in browsers that hadn't dismissed it even though the second should be the one showing since the 21st, so I fixed the condition (JS doesn't support chained comparison operators like Python does) and now it should work properly.