### PR TITLE
fix(posts): remove old domain from link

### DIFF
--- a/posts/2015/03/23/why-should-congress-care-about-pacer.mdx
+++ b/posts/2015/03/23/why-should-congress-care-about-pacer.mdx
@@ -10,7 +10,7 @@ This is the second of three short posts on PACER:
 - [What is the "PACER Problem"?](/2015/03/20/what-is-the-pacer-problem/)
 -   Why Should Congress Care About PACER?
 -   [What Should be Done About the PACER
-    Problem?](http://freelawproject.org/2015/03/24/what-should-be-done-about-the-pacer-problem/)
+    Problem?](/2015/03/24/what-should-be-done-about-the-pacer-problem/)
 
 There are several reasons that Congress should care about PACER:
 


### PR DESCRIPTION
I was reading the `What is the "PACER Problem"?` blog posts and noticed a link had a hardcoded old domain so I fixed it.

Preview post [here](https://deploy-preview-262--freelaw.netlify.app/2015/03/23/why-should-congress-care-about-pacer)
Prod post [here](https://free.law/2015/03/23/why-should-congress-care-about-pacer)