### PR TITLE
fix(recap.mdx): avoid buttons from bumping into each other

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -1,8 +1,13 @@
 import Link from 'next/link';
+import {Popover, Transition} from "@headlessui/react";
+import {Fragment} from "react";
+import {ChevronDownIcon} from "@heroicons/react/solid";
+import {DownloadIcon} from "@heroicons/react/outline";
+
+const BASE_BUTTON_CLASSES = 'text-center whitespace-nowrap border border-transparent rounded-md shadow-sm text-base font-medium text-white text-sm no-underline';
 
 export default function Button({ children, href, extraClasses, size }) {
-  let classes =
-    'text-center whitespace-nowrap border border-transparent rounded-md shadow-sm text-base font-medium text-white text-sm no-underline';
+  let classes = BASE_BUTTON_CLASSES;
   if (extraClasses) {
     classes += ' ' + extraClasses;
   }
@@ -90,5 +95,85 @@ export function FooterLink({ children, href }) {
         <a className="text-gray-500 hover:underline">{children}</a>
       </Link>
     </p>
+  );
+}
+
+export function InstallRECAPButtons() {
+  const addToChromeButton = (
+      <PurpleButton size="lg" href="https://chrome.google.com/webstore/detail/recap/oiillickanjlaeghobeeknbddaonmjnc"
+        extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Chrome</PurpleButton>);
+  const addToEdgeButton = (
+      <PurpleButton size="lg" href="https://microsoftedge.microsoft.com/addons/detail/ckkpjgceaenndjdjpbaoaociikjpfdjg"
+        extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Edge</PurpleButton>);
+  const addToSafariButton = (
+      <PurpleButton size="lg" href="https://apps.apple.com/us/app/recap/id1600281788"
+        extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Safari&nbsp;</PurpleButton>
+  );
+  const addToFirefoxButton = (
+      <PurpleButton size="lg" href="https://addons.mozilla.org/en-US/firefox/addon/recap-195534/"
+        extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Firefox&nbsp;</PurpleButton>
+  );
+  return (
+    <>
+    <div className="hidden md:grid grid-cols-4 gap-x-1 justify-center">
+      <div className="col-span-1 flex justify-center">
+        {addToChromeButton}
+      </div>
+      <div className="col-span-1 flex justify-center">
+        {addToEdgeButton}
+      </div>
+      <div className="col-span-1 flex justify-center">
+        {addToSafariButton}
+      </div>
+      <div className="col-span-1 flex justify-center">
+        {addToFirefoxButton}
+      </div>
+    </div>
+
+    <ButtonWithPopover buttonText="Install RECAP" extraClasses="md:hidden">
+      <div className="flex flex-col gap-2 bg-white rounded-xl shadow-lg p-10 border border-purple-100">
+        {addToChromeButton}
+        {addToEdgeButton}
+        {addToSafariButton}
+        {addToFirefoxButton}
+      </div>
+    </ButtonWithPopover>
+    </>
+  );
+}
+
+export function ButtonWithPopover({children, buttonText, extraClasses }) {
+  const classes = extraClasses ? `relative ${extraClasses}` : 'relative';
+  return (
+    <Popover className={classes}>
+      {({ open }) => (
+        <>
+          <Popover.Button
+            className={`
+              ${open ? 'text-white' : 'text-white/90'}
+              ${BASE_BUTTON_CLASSES} px-6 py-4 text-lg bg-purple-800 hover:bg-purple-900 flex flex-nowrap mx-auto`}
+          >
+            {buttonText}
+            <ChevronDownIcon
+              className={`${open ? 'transform rotate-180' : ''} ml-2 w-5 transition duration-150 ease-in-out`}
+              aria-hidden="true"
+            />
+          </Popover.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <Popover.Panel className="absolute left-1/2 z-10 mt-3 w-screen max-w-sm -translate-x-1/2 transform px-4 sm:px-0 lg:max-w-3xl">
+              {children}
+            </Popover.Panel>
+          </Transition>
+        </>
+      )}
+    </Popover>
   );
 }

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -12,6 +12,7 @@ import {
 } from '../components/widgets';
 import {ClientPics, PicGrid} from '../components/layout';
 import Button, {
+  InstallRECAPButtons,
   PurpleButton,
   RedButton,
   WhiteButton,
@@ -43,6 +44,7 @@ export const mdxComponents = {
 
   // Buttons
   Button,
+  InstallRECAPButtons,
   RedButton,
   PurpleButton,
   WhiteButton,

--- a/posts/recap.mdx
+++ b/posts/recap.mdx
@@ -9,24 +9,8 @@ imagePath: "/images/banners/recap.png"
 
 If you use PACER, consider installing the RECAP extension in your browser. If you are a researcher, you can search millions of federal filings in the <a href="https://www.courtlistener.com/recap/">RECAP Archive</a>. Journalists and court watchers will find <a href="/2023/03/13/what-is-in-the-recap-suite/">docket alerts</a> invaluable. If you get notifications from PACER, check out <a href="/help/recap/email/">our NEF notification handler</a>.
 
-<div className="grid grid-cols-4 gap-x-1 gap-y-2 justify-center">
-  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
-    <PurpleButton size="lg" href="https://chrome.google.com/webstore/detail/recap/oiillickanjlaeghobeeknbddaonmjnc" 
-                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Chrome</PurpleButton>
-  </div>
-  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
-    <PurpleButton size="lg" href="https://microsoftedge.microsoft.com/addons/detail/ckkpjgceaenndjdjpbaoaociikjpfdjg" 
-                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Edge</PurpleButton> 
-  </div>
-  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
-    <PurpleButton size="lg" href="https://apps.apple.com/us/app/recap/id1600281788"
-                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Safari&nbsp;</PurpleButton>
-  </div>
-  <div className="col-span-2 md:col-span-1 md:flex md:justify-center">
-    <PurpleButton size="lg" href="https://addons.mozilla.org/en-US/firefox/addon/recap-195534/"
-                  extraClasses="inline-flex md:px-4 sm:text-md md:py-2"><DownloadIcon className="flex-shrink-0 h-4 w-4" aria-hidden="true"/>&nbsp;Add to Firefox&nbsp;</PurpleButton>
-  </div>
-</div>
+<InstallRECAPButtons/>
+
 <br/>
 
 


### PR DESCRIPTION
Fixes #266 

This PR adds two new components:
- `ButtonWithPopover`: A reusable component that provides a purple button with an empty Popover.
- `InstallRECAPButtons`: A responsive component for the 'Install RECAP' buttons set, that uses the button with Popover component in smaller screens as shown below, while displaying the buttons in a row in larger screens same as before.

[Screencast from 05-02-2025 05:21:04 PM.webm](https://github.com/user-attachments/assets/1abcea44-8337-4f5a-a3cb-10da0e4e36f1)
