### PR TITLE
fix(posts): add max width to iframe to avoid overflow in smaller screens in OA Transcripts blog post

### DIFF
--- a/posts/2025/07/31/oral-argument-transcripts.mdx
+++ b/posts/2025/07/31/oral-argument-transcripts.mdx
@@ -20,7 +20,7 @@ We are proud that this feature enhances accessibility for the deaf and hard of h
 
 ## 🔍 How to Use the New Transcripts Feature
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/JwA3r66_Sp0?si=IYRx1ZbVwWSrWfkM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe className="max-w-full" width="560" height="315" src="https://www.youtube.com/embed/JwA3r66_Sp0?si=IYRx1ZbVwWSrWfkM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 <p className="text-center">
   <PurpleButton href="https://www.youtube.com/watch?v=JwA3r66_Sp0" size="lg">Watch on YouTube</PurpleButton>
 </p>


### PR DESCRIPTION
I read the blog post on my phone and noticed it looked quite different from what I'd seen in the desktop browser:

<img width="200" alt="image" src="https://github.com/user-attachments/assets/dfc1d35a-ddfc-4de5-889d-c42516ce3903" />

So I added a max width and it fixed the issue 👍🏽 

## Before

<img width="250" alt="image" src="https://github.com/user-attachments/assets/8b47d65a-6432-47cd-918b-cd48fda567d0" />

## After

<img width="250" alt="image" src="https://github.com/user-attachments/assets/90c803fe-d0a4-43b3-9d5a-f7398079eecc" />
