### PR TITLE
feat(posts): add post about FLP at IRE 2025

### DIFF
--- a/posts/2025/08/25/ire25.mdx
+++ b/posts/2025/08/25/ire25.mdx
@@ -15,19 +15,29 @@ excerpt: "We’re proud to share that William Palin, Case Law Lead at Free Law P
 ## Why This Matters:
 
 Court transparency is a cornerstone of democracy, but access is often complicated by outdated systems, high fees, and inconsistent practices across jurisdictions. William highlighted how Free Law Project works to address these challenges by:
-- <a className="font-bold" href="https://www.courtlistener.com/">CourtListener:</a> Our free legal research platform with millions of opinions, docket alerts, and advanced search features.
-- <a className="font-bold" href="https://www.courtlistener.com/recap/">RECAP Archive:</a> The largest open collection of federal court filings—crowdsourced from PACER and freely available to the public.
-- <span className="font-bold text-black">New Tools:</span> <a href="https://free.law/2025/06/18/recap-search-alerts-for-pacer/">Search Alerts</a>, <a href="https://free.law/2025/07/31/oral-argument-transcripts/">Oral Argument transcripts</a>, <a href="https://www.courtlistener.com/help/api/rest/">APIs</a>, and <a href="https://www.courtlistener.com/help/api/webhooks/getting-started/">webhooks</a> that make it easier than ever to follow cases and investigate issues.
+- [**CourtListener:**][courtlistener] Our free legal research platform with millions of opinions, docket alerts, and advanced search features.
+- [**RECAP Archive:**][recap] The largest open collection of federal court filings—crowdsourced from PACER and freely available to the public.
+- **New Tools:** [Search Alerts][alerts], [Oral Argument transcripts][oa-transcripts], [APIs][apis], and [webhooks][webhooks] that make it easier than ever to follow cases and investigate issues.
 
 By making the law accessible to everyone—not just those with deep pockets—we’re helping journalists shine a light on the courts and keep the public informed.
 
 ## Resources from the Session:
 
 Want to dive deeper? Here are the materials from the panel:
-- <a href="https://github.com/user-attachments/files/21919987/IRE.panel.-.Covering.Courts.pdf">Slides</a>
-- <a href="https://github.com/user-attachments/files/21920047/OFFICIAL.Tip.Sheet_.Covering.Courts.IRE.2025.pdf">Tip Sheet</a>
-- <a href="https://resources.ire.org/audio/20250620-31554.mp3">Audio Recording</a>
+- [Slides][slides]
+- [Tip Sheet][tip-sheet]
+- [Audio Recording][recording]
 
 ## Looking Ahead:
 
 Free Law Project will continue to innovate and advocate for open access to the courts. We’re grateful to IRE for convening this important conversation and to all the journalists who use our tools to hold institutions accountable.
+
+[courtlistener]: https://www.courtlistener.com/
+[recap]: https://www.courtlistener.com/recap/
+[alerts]: https://free.law/2025/06/18/recap-search-alerts-for-pacer/
+[oa-transcripts]: https://free.law/2025/07/31/oral-argument-transcripts/
+[apis]: https://www.courtlistener.com/help/api/rest/
+[webhooks]: https://www.courtlistener.com/help/api/webhooks/getting-started/
+[slides]: https://github.com/user-attachments/files/21919987/IRE.panel.-.Covering.Courts.pdf
+[tip-sheet]: https://github.com/user-attachments/files/21920047/OFFICIAL.Tip.Sheet_.Covering.Courts.IRE.2025.pdf
+[recording]: https://resources.ire.org/audio/20250620-31554.mp3

--- a/posts/2025/08/25/ire25.mdx
+++ b/posts/2025/08/25/ire25.mdx
@@ -1,0 +1,33 @@
+---
+title: "Free Law Project at IRE 2025: Covering Courts with William Palin"
+date: "2025-08-25"
+tags:
+ - "William Palin"
+ - "IRE2025"
+ - "Investigative Reporters and Editors"
+ - "Conferences"
+author: "Jenifer Whiston"
+excerpt: "We’re proud to share that William Palin, Case Law Lead at Free Law Project, joined an outstanding panel of reporters and attorneys at the Investigative Reporters and Editors (IRE) Conference 2025 to discuss Covering Courts: How to Access Court Records & Navigate Trials."
+---
+
+<p className="lead">Alongside journalists and legal experts, William shared how Free Law Project’s tools help reporters, researchers, and the public overcome barriers to court transparency.</p>
+
+## Why This Matters:
+
+Court transparency is a cornerstone of democracy, but access is often complicated by outdated systems, high fees, and inconsistent practices across jurisdictions. William highlighted how Free Law Project works to address these challenges by:
+- <a className="font-bold" href="https://www.courtlistener.com/">CourtListener:</a> Our free legal research platform with millions of opinions, docket alerts, and advanced search features.
+- <a className="font-bold" href="https://www.courtlistener.com/recap/">RECAP Archive:</a> The largest open collection of federal court filings—crowdsourced from PACER and freely available to the public.
+- <span className="font-bold text-black">New Tools:</span> <a href="https://free.law/2025/06/18/recap-search-alerts-for-pacer/">Search Alerts</a>, <a href="https://free.law/2025/07/31/oral-argument-transcripts/">Oral Argument transcripts</a>, <a href="https://www.courtlistener.com/help/api/rest/">APIs</a>, and <a href="https://www.courtlistener.com/help/api/webhooks/getting-started/">webhooks</a> that make it easier than ever to follow cases and investigate issues.
+
+By making the law accessible to everyone—not just those with deep pockets—we’re helping journalists shine a light on the courts and keep the public informed.
+
+## Resources from the Session:
+
+Want to dive deeper? Here are the materials from the panel:
+- <a href="https://github.com/user-attachments/files/21919987/IRE.panel.-.Covering.Courts.pdf">Slides</a>
+- <a href="https://github.com/user-attachments/files/21920047/OFFICIAL.Tip.Sheet_.Covering.Courts.IRE.2025.pdf">Tip Sheet</a>
+- <a href="https://resources.ire.org/audio/20250620-31554.mp3">Audio Recording</a>
+
+## Looking Ahead:
+
+Free Law Project will continue to innovate and advocate for open access to the courts. We’re grateful to IRE for convening this important conversation and to all the journalists who use our tools to hold institutions accountable.


### PR DESCRIPTION
Closes #317 

[Link to post preview](https://deploy-preview-319--freelaw.netlify.app/2025/08/25/ire25)

**Question:** is 08/25 the right date for this post? [the one about FLP at ILTACon25](https://github.com/freelawproject/free.law/pull/318) is meant to be posted today. [This](https://github.com/freelawproject/free.law/issues/317#issuecomment-3226278194) is why I ask:

> Maybe we can merge them both in one PR to make your life easier, but announce them on separate days so we don't saturate our news feed? So maybe post-date one for Monday or something?

Since we wanted different dates I simply opened two separate PRs, so we can merge on different days if needed.

<details>
<summary>Screenshots</summary>

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a1a34267-2b76-4aab-94f7-4b7cc95114e6" />


<img width="900" alt="image" src="https://github.com/user-attachments/assets/0315bdd1-b8cc-45f4-aa56-a6d190601d92" />

</details>
