### PR TITLE
feat(footer): remove Twitter and replace with Bluesky link to FLP account

### DIFF
--- a/components/footers.js
+++ b/components/footers.js
@@ -133,7 +133,7 @@ export function Colophon() {
         <div className="w-full sm:w-3/5">
           <p className="flex flex-row justify-center sm:justify-end gap-6 pt-6 sm:pt-0">
             <Link href="https://bsky.app/profile/free.law">
-              <a className="text-gray-400 w-8 h-8">
+              <a className="text-gray-400 hover:text-gray-500 w-8 h-8">
                 <BlueskyLogo></BlueskyLogo>
               </a>
             </Link>
@@ -141,7 +141,7 @@ export function Colophon() {
               <a rel="me">
                 <FontAwesomeIcon
                   icon={faMastodon}
-                  className="w-8 text-gray-400"
+                  className="w-8 text-gray-400 hover:text-gray-500"
                   mask={faCircle}
                   inverse
                   transform="shrink-6"
@@ -152,7 +152,7 @@ export function Colophon() {
               <a>
                 <FontAwesomeIcon
                   icon={faNewspaper}
-                  className="w-8 text-gray-400"
+                  className="w-8 text-gray-400 hover:text-gray-500"
                   mask={faCircle}
                   inverse
                   transform="shrink-6"
@@ -161,7 +161,7 @@ export function Colophon() {
             </Link>
             <Link href="https://github.com/freelawproject/">
               <a>
-                <FontAwesomeIcon icon={faGithub} className="w-8 text-gray-400" />
+                <FontAwesomeIcon icon={faGithub} className="w-8 text-gray-400 hover:text-gray-500" />
               </a>
             </Link>
           </p>

--- a/components/footers.js
+++ b/components/footers.js
@@ -2,10 +2,11 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { H5 } from './headings';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGithub, faMastodon, faTwitter } from '@fortawesome/free-brands-svg-icons';
+import { faGithub, faMastodon } from '@fortawesome/free-brands-svg-icons';
 import { FooterLink } from './button';
 import { faCircle, faNewspaper } from '@fortawesome/free-solid-svg-icons';
 import { MainFullBleedColumn } from './layout';
+import { BlueskyLogo } from './widgets';
 
 export function Footer({ recentPost }) {
   return (
@@ -131,15 +132,9 @@ export function Colophon() {
         </div>
         <div className="w-full sm:w-3/5">
           <p className="flex flex-row justify-center sm:justify-end gap-6 pt-6 sm:pt-0">
-            <Link href="https://twitter.com/freelawproject">
-              <a>
-                <FontAwesomeIcon
-                  icon={faTwitter}
-                  className="w-8 text-gray-400"
-                  mask={faCircle}
-                  inverse
-                  transform="shrink-6"
-                />
+            <Link href="https://bsky.app/profile/free.law">
+              <a className="text-gray-400 w-8 h-8">
+                <BlueskyLogo></BlueskyLogo>
               </a>
             </Link>
             <Link href="https://law.builders/@flp">

--- a/components/widgets.js
+++ b/components/widgets.js
@@ -176,3 +176,22 @@ export function Spinner({ extraClasses }) {
   return (
     <div className={classes}></div>);
 }
+
+/**
+ *  FontAwesome doesn't have an official Bluesky Logo, so we use a React component to
+ *  insert the svg directly without an `<img>` tag, thus enabling color customization.
+ *  */
+export function BlueskyLogo() {
+  return (<svg
+    xmlns="http://www.w3.org/2000/svg"
+    shapeRendering="geometricPrecision"
+    textRendering="geometricPrecision"
+    imageRendering="optimizeQuality"
+    fillRule="evenodd"
+    clipRule="evenodd"
+    viewBox="0 0 512 512"
+    fill="currentColor"
+  >
+    <path d="M256 0c141.385 0 256 114.615 256 256S397.385 512 256 512 0 397.385 0 256 114.615 0 256 0zm-72.224 158.537c29.233 22.022 60.681 66.666 72.223 90.624 11.543-23.958 42.993-68.602 72.225-90.624 21.097-15.886 55.276-28.181 55.276 10.937 0 7.809-4.464 65.631-7.084 75.02-9.1 32.629-42.271 40.953-71.774 35.917 51.572 8.805 64.69 37.97 36.357 67.136-53.809 55.394-77.341-13.898-83.366-31.653-1.737-5.111-1.489-5.228-3.267 0-6.026 17.755-29.555 87.047-83.364 31.653-28.334-29.166-15.216-58.331 36.356-67.136-29.503 5.036-62.674-3.288-71.774-35.917-2.62-9.389-7.084-67.211-7.084-75.02 0-39.118 34.183-26.823 55.276-10.937z" fill="currentColor"/>
+  </svg>);
+}


### PR DESCRIPTION
Closes #322 

This PR removes Twitter and includes Bluesky in the footer.

Note the logo was added as a React component because FontAwesome doesn't have an official Bluesky logo, and color customizarion doesn't work in an `<img>` tag, so we inject the `<svg>` inline for this purpose.

Also, since we have a hover state for most links in the rest of the page, I added a subtle hover state to the logos. If we don't like it we can simply roll back the commit, but I think it looks better this way.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f9599118-645b-41b2-bfcb-349e6d3a2dcf" />


## Before

<img width="800" alt="image" src="https://github.com/user-attachments/assets/fa8e602e-fec7-4f96-ac61-2ebe583334fb" />

## After

<img width="800" alt="image" src="https://github.com/user-attachments/assets/70cefa9b-46e0-427c-91ec-e4712843f32d" />
