### PR TITLE
Correct link to Internet Archive collection

### DIFF
--- a/posts/recap.mdx
+++ b/posts/recap.mdx
@@ -134,7 +134,7 @@ We also have an API and bulk data available for developers. For details, [get in
 [free]: /2017/08/15/we-have-all-free-pacer/
 [bulk]: /data-consulting/
 [archive]: https://www.courtlistener.com/recap/
-[ia]: https://archive.org/details/usfederalcourts&tab=about
+[ia]: https://archive.org/details/usfederalcourts?tab=about
 [ia-itself]: https://archive.org
 [citp]: https://citp.princeton.edu/
 [yee]: http://zesty.ca/


### PR DESCRIPTION
As originally written, the "a lasting home" link goes to a page that says, "The search engine encountered an error while loading this collection." The `tab=about` portion needs to be represented properly as a GET query string.