### PR TITLE
fix(hiring): remove buttons from closed positions

### DIFF
--- a/posts/hiring.mdx
+++ b/posts/hiring.mdx
@@ -162,9 +162,6 @@ This is a benefits-eligible position. Free Law Project offers paid time-off, com
 
 Free Law Project is an equal opportunity employer. The Company offers employment opportunities to all applicants and employees without regard to race, color, religion, national origin, sex, sexual orientation, gender identity or expression, age, disability, medical condition, marital status, veteran status, citizenship, genetic information, hairstyles, or any other status protected by local or federal law.
 
-<p className="text-center pt-5">
-    <PurpleButton href="https://docs.google.com/forms/d/e/1FAIpQLSdbRrrOiKu74tgt7wJ1HEEz1XFRyn2XwYpIryxcB6aRJqd0_g/viewform?usp=sf_link" size="lg" extraClasses="inline-flex"><CheckIcon className="flex-shrink-0 h-7 w-7 pr-1"/> Submit Your Application</PurpleButton>
-</p>
 
 ## Operations Manager (Full Time / Remote / Closed)
 
@@ -217,10 +214,6 @@ Key tasks include but are not limited to:
  - The base salary range for this US-based, full-time, remote, and exempt position begins at $70,000, not including variable compensation.
  - This is a benefits-eligible position. Free Law Project offers paid time-off, company paid holidays, SIMPLE IRA retirement program with a company elected match, bereavement leave, and assistance with health insurance premiums.
  - Free Law Project is an equal opportunity employer. The Company offers employment opportunities to all applicants and employees without regard to race, color, religion, national origin, sex, sexual orientation, gender identity or expression, age, disability, medical condition, marital status, veteran status, citizenship, genetic information, hairstyles, or any other status protected by local or federal law.
-
-<p className="text-center pt-5">
-    <PurpleButton href="https://docs.google.com/forms/d/e/1FAIpQLSdbRrrOiKu74tgt7wJ1HEEz1XFRyn2XwYpIryxcB6aRJqd0_g/viewform?usp=sf_link" size="lg" extraClasses="inline-flex"><CheckIcon className="flex-shrink-0 h-7 w-7 pr-1"/> Submit Your Application</PurpleButton>
-</p>
 
 
 ## Technical Partnerships Manager (Closed)
@@ -280,10 +273,6 @@ Key tasks include but are not limited to:
  - The base salary range for this US-based, full-time, remote, and exempt position begins at $97,000, not including variable compensation.
  - This is a benefits-eligible position. Free Law Project offers paid time-off, company paid holidays, SIMPLE IRA retirement program with a company elected match, bereavement leave, and assistance with health insurance premiums.
  - Free Law Project is an equal opportunity employer. The Company offers employment opportunities to all applicants and employees without regard to race, color, religion, national origin, sex, sexual orientation, gender identity or expression, age, disability, medical condition, marital status, veteran status, citizenship, genetic information, hairstyles, or any other status protected by local or federal law.
-
-<p className="text-center pt-5">
-    <PurpleButton href="https://docs.google.com/forms/d/e/1FAIpQLSdbRrrOiKu74tgt7wJ1HEEz1XFRyn2XwYpIryxcB6aRJqd0_g/viewform?usp=sf_link" size="lg" extraClasses="inline-flex"><CheckIcon className="flex-shrink-0 h-7 w-7 pr-1"/> Submit Your Application</PurpleButton>
-</p>
 
 
 ## AI Developer (Full Time / 6 month contract with possibility of long term hire / Remote, Closed)


### PR DESCRIPTION
I noticed some of the closed positions still have the button to apply, which seems odd/potentially confusing, so I removed them.

There's one at the end too and I didn't remove it, I kinda like it there for some reason 🤔 works as a CTA if someone scrolled all the way down, that way they don't have to scroll all the way up again if they do want to apply?