### PR TITLE
fix(layout.js): ensure YouTube embeds set referrerPolicy correctly

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -293,7 +293,7 @@ export function ClientPics({ wide }) {
 export function ResponsiveIFrame({
   src,
   allow,
-  referrer,
+  referrerPolicy,
   className = 'w-full aspect-video',
   title = 'Embedded content',
 }) {
@@ -302,7 +302,7 @@ export function ResponsiveIFrame({
       className={className}
       src={src}
       title={title}
-      referrerPolicy={referrer}
+      referrerPolicy={referrerPolicy}
       allow={allow}
       allowFullScreen
     />


### PR DESCRIPTION
Fix for #391

ResponsiveIFrame and YouTubeVideo were using slightly different prop names, preventing referrerPolicy from being applied to YouTube iframes. This caused embed failures under strict CSP.

Small tweak to sync up names.  