### PR TITLE
Update RECAP Fundraiser Page URL and Donate Link

### DIFF
--- a/posts/fundraiser/recap.mdx
+++ b/posts/fundraiser/recap.mdx
@@ -26,5 +26,5 @@ We need your support to continue enhancing and maintaining the RECAP system. If 
 [//]: # (</div>)
 
 <div className="flex w-full justify-center">
-  <RedButton href="https://donate.free.law/forms/supportflp" size="lg">Donate Now</RedButton>
+  <RedButton href="https://donate.free.law/forms/support-recap" size="lg">Donate Now</RedButton>
 </div>


### PR DESCRIPTION
## Summary
This PR updates the RECAP fundraiser page to remove the year from the URL path and updates the donate button link.

### Changes Made
1. **URL Updated**: Moved page from `/fundraiser/2024/recap` to `/fundraiser/recap`
   - Creates an evergreen URL that doesn't need annual updates
   - Old path: `posts/fundraiser/2024/recap.mdx`
   - New path: `posts/fundraiser/recap.mdx`

2. **Donate Button Updated**: Changed the "Donate Now" button link
   - Old: `https://donate.free.law/forms/supportflp`
   - New: `https://donate.free.law/forms/support-recap`
   - Now directs users to the RECAP-specific donation form

### Files Changed
- `posts/fundraiser/recap.mdx` (moved and updated)

### Related Issues
- Closes #407 (Update EOY giving - RECAP pop up page)

### Notes
- This change is required before recap/issues/400 can be completed (as noted in issue comments)
- Deadline: 12/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)