### PR TITLE
Blog Post: HeinOnline CourtListener Integration Announcement

### DIFF
--- a/posts/2025/12/10/heinonline-courtlistener-integration.mdx
+++ b/posts/2025/12/10/heinonline-courtlistener-integration.mdx
@@ -1,0 +1,53 @@
+---
+title: "CourtListener in More Places: What the HeinOnline Integration Signals for Open Legal Data"
+date: "2025-12-10"
+tags:
+  - "Free Law Project"
+  - "CourtListener"
+  - "HeinOnline"
+  - "Open Legal Data"
+  - "Legal Research"
+author: "Jessica Frank"
+excerpt: "Last week, HeinOnline announced a new case law offering powered by CourtListener. We see this announcement as part of a larger movement: open legal data is becoming recognized as a crucial foundation for legal research, education, and public engagement with the courts."
+---
+
+<p className="lead">Last week, HeinOnline [announced][heinonline-announcement] a new case law offering powered by CourtListener. We, at Free Law Project, see this announcement as part of a larger movement: open legal data is becoming recognized as a crucial foundation for legal research, education, and public engagement with the courts.</p>
+
+CourtListener has always been built as a public-first resource — a free, open, and continuously growing archive of court opinions, oral arguments, and docket information. Seeing it appear inside another major research environment is a reminder that open systems do not exist in competition with the legal ecosystem, but in support of it.
+
+## Why This Matters
+
+The value of this integration is not about branding or distribution alone. It reflects something larger:
+
+**Open legal data is no longer optional.**
+
+Researchers, students, journalists, and practitioners increasingly expect comprehensive access to the law — not only to final opinions, but to context: dockets, parties, judges, and procedural history. CourtListener was built to make that context accessible, structured, and useful.
+
+**Open infrastructure scales.**
+
+CourtListener currently includes millions of judicial opinions and continues to grow every day. The technology and data behind it were designed from the beginning to support both public users and institutional use at scale. Integrations like this demonstrate that open systems can meet real-world research demands.
+
+**Access to law improves everywhere when data is open.**
+
+Whether someone encounters CourtListener through our own interface, an API, or an external platform, the outcome is the same: more people encountering law that is easier to search, analyze, and understand. Open data improves downstream tools, workflows, and research environments — even when users never see the infrastructure directly.
+
+## What This Says About the Future of Legal Research
+
+For years, open legal data was treated as peripheral: useful, but separate from "serious" research environments. That distinction is fading.
+
+Today, open data is no longer an experiment on the margins. It is part of the foundation on which many research systems are being built — powering search, fueling analytics, enabling AI tools, and supporting transparency across the legal system.
+
+The increasingly visible role of projects like CourtListener reflects a broader truth: access to law does not depend on a single product or platform. It depends on shared infrastructure, maintained for the public good and available to everyone.
+
+## A Reminder — and a Call to Action
+
+Integrations are milestones, not endpoints. CourtListener exists because thousands of contributors — librarians, court staff, journalists, technologists, and volunteers — have helped expand and improve it. The work continues every day: adding missing opinions, correcting metadata, improving coverage, and building better ways to organize the law.
+
+If you use CourtListener through HeinOnline, directly on [CourtListener.com][courtlistener], through our APIs, or through one of many downstream tools, you are part of that ecosystem.
+
+And if you notice something missing — a case, a court, a document type — tell us. Open legal data is only as strong as the community that supports it.
+
+At Free Law Project, we remain committed to building and maintaining public legal infrastructure that serves everyone — not just today's users, but tomorrow's as well.
+
+[heinonline-announcement]: https://home.heinonline.org/blog/2025/12/meet-courtlistener-your-new-case-law-power-tool/
+[courtlistener]: https://www.courtlistener.com/


### PR DESCRIPTION
## Summary
This PR adds a blog post announcing HeinOnline's new Case Law Premium offering powered by CourtListener, reflecting on what this integration means for the open legal data movement.

### Key Content
- Announces HeinOnline's integration of CourtListener into their case law research platform
- Discusses three key reasons why this integration matters:
  - Open legal data is no longer optional
  - Open infrastructure scales
  - Access to law improves everywhere when data is open
- Examines what this signals about the future of legal research
- Calls the community to continue supporting and improving CourtListener
- Emphasizes that open systems support, rather than compete with, the legal ecosystem

### Scheduling
- **Publish Date**: December 10, 2025 (mid next week)
- As requested by Jessica in comments, scheduled for mid next week since 2 posts authored by her were already published this week (Dec 1 & Dec 3)

### Files Changed
- `posts/2025/12/10/heinonline-courtlistener-integration.mdx` - New blog post

### Related Issues
- Closes #414 (Draft blog post about HeinOnline's Case Law Premium announcement)

### Formatting Notes
- All links converted to footnote format per project standards
- Proper frontmatter with tags and excerpt
- Lead paragraph with main announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)