### PR TITLE
Update EOY Popup Donate Link

### DIFF
--- a/components/dialog.js
+++ b/components/dialog.js
@@ -173,7 +173,7 @@ export function EOYDialog() {
             </p>
           </div>
           <div className="my-6 w-full flex justify-end">
-            <Button href="https://donate.free.law/forms/supportflp" extraClasses={buttonClasses}>
+            <Button href="https://donate.free.law/forms/eoyflpsupport" extraClasses={buttonClasses}>
               <H1 extraClasses="font-extrabold">Make your donation today</H1>
             </Button>
           </div>


### PR DESCRIPTION
## Summary
This PR updates the donate button link in the End-of-Year (EOY) popup dialog to use the EOY-specific donation form.

### Changes Made
- Updated donate button URL in `EOYDialog` component
- Changed from: `https://donate.free.law/forms/supportflp`
- Changed to: `https://donate.free.law/forms/eoyflpsupport`

### Context
- Part of the 2025 EOY appeal campaign
- The EOY popup appears on Free.Law between December 4-31
- Uses a two-phase dialog system with different messaging

### Files Changed
- `components/dialog.js` - Updated button href on line 176

### Related Issues
- Closes #417 (EOY Pop-up on Free.Law)
- Part of freelawproject/internal#685 (2025 EOY appeal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)