### PR TITLE
Fix overscroll background color to match navbar

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -1,6 +1,15 @@
 @config "../tailwind.config.js";
 @import "tailwindcss";
 
+/* Match overscroll background to navbar color */
+html {
+  background-color: #180040;
+}
+
+body {
+  background-color: white;
+}
+
 @theme {
   --background-image-imgScotus: url('/images/homepage/scotus-hero.jpeg');
   --background-image-imgJudgeHr: url('/images/homepage/judge-hr.jpeg');


### PR DESCRIPTION
## Summary
- Set html background to purple-900 (#180040) to match navbar color in overscroll areas
- Keep body background white for page content

This ensures a consistent purple color when scrolling beyond the top of the page (the "rubber band" effect on some browsers), rather than showing white.

## Changes
- Updated `styles/global.css` to set html and body backgrounds appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)