### PR TITLE
feat(homepage): add Our Impact stats section

### DIFF
--- a/components/headings.js
+++ b/components/headings.js
@@ -15,10 +15,10 @@ export function HeroHeading({ children, tag, ...props }) {
   );
 }
 
-export function HeroHeadingMono({ children, tag }) {
+export function HeroHeadingMono({ children, tag, ...props }) {
   const Tag = tag ?? "h1";
   return (
-    <Tag className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-widest font-mono">
+    <Tag {...props} className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-widest font-mono">
       {children}
     </Tag>
   );
@@ -32,9 +32,9 @@ export function H1({ children, extraClasses }) {
   return <h1 className={classes}>{children}</h1>;
 }
 
-export function H2({ children }) {
+export function H2({ children, ...props }) {
   return (
-    <h2 className="text-2xl md:text-3xl lg:text-4xl leading-[2.5rem] md:leading-[2.5rem] lg:leading-[3rem] tracking-wide font-display">
+    <h2 {...props} className="text-2xl md:text-3xl lg:text-4xl leading-[2.5rem] md:leading-[2.5rem] lg:leading-[3rem] tracking-wide font-display">
       {children}
     </h2>
   );

--- a/components/headings.js
+++ b/components/headings.js
@@ -6,10 +6,10 @@ export function H1Hero({ children }) {
   );
 }
 
-export function HeroHeading({ children, tag }) {
+export function HeroHeading({ children, tag, ...props }) {
   const Tag = tag ?? "h1";
   return (
-    <Tag className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-display font-light leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-wide">
+    <Tag {...props} className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-display font-light leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-wide">
       {children}
     </Tag>
   );

--- a/components/headings.js
+++ b/components/headings.js
@@ -6,19 +6,21 @@ export function H1Hero({ children }) {
   );
 }
 
-export function HeroHeading({ children }) {
+export function HeroHeading({ children, tag }) {
+  const Tag = tag ?? "h1";
   return (
-    <h1 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-display font-light leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-wide">
+    <Tag className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-display font-light leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-wide">
       {children}
-    </h1>
+    </Tag>
   );
 }
 
-export function HeroHeadingMono({ children }) {
+export function HeroHeadingMono({ children, tag }) {
+  const Tag = tag ?? "h1";
   return (
-    <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-widest font-mono">
+    <Tag className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl leading-[2.5rem] sm:leading-[3rem] md:leading-[4rem] lg:leading-[5rem] tracking-widest font-mono">
       {children}
-    </h1>
+    </Tag>
   );
 }
 

--- a/components/layout.js
+++ b/components/layout.js
@@ -26,9 +26,9 @@ export function MainColumn({ children }) {
   return <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-10">{children}</div>;
 }
 
-export function MainFullBleedColumn({ bgClasses, children }) {
+export function MainFullBleedColumn({ bgClasses, children, ...props }) {
   return (
-    <section className={bgClasses}>
+    <section className={bgClasses} {...props}>
       <MainColumn>{children}</MainColumn>
     </section>
   );

--- a/components/layout.js
+++ b/components/layout.js
@@ -165,6 +165,17 @@ export function PicGrid({ wide, tall, children }) {
   );
 }
 
+export function ImpactStat({ label, ariaLabel, value }) {
+  return (
+    <div className="flex flex-col-reverse justify-center">
+      <dt className="text-lg font-mono font-bold text-gray-600 mt-2">{label}</dt>
+      <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label={ariaLabel}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
 export function ClientPics({ wide }) {
   return (
     <PicGrid wide={wide}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import Head from 'next/head';
-import Layout, { ClientPics, MainColumn, MainFullBleedColumn } from '../components/layout';
+import Layout, { ClientPics, MainColumn, MainFullBleedColumn, ImpactStat } from '../components/layout';
 import { getSortedPostsData } from '../lib/posts';
 import Button, { PurpleButton, WhiteButton } from '../components/button';
 import { EOYDialog } from '../components/dialog';
@@ -43,42 +43,12 @@ export default function Home({ allPostsData }) {
           </div>
           <div className="py-16" id="impact">
             <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-18 text-center">
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Downloads Served</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 800 million">
-                  800+ million
-                </dd>
-              </div>
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Pages of Court Data</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 250 million">
-                  250+ million
-                </dd>
-              </div>
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">API Requests Served</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 100 million">
-                  100+ million
-                </dd>
-              </div>
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Emails Sent</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 5.4 million">
-                  5.4+ million
-                </dd>
-              </div>
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Monthly Visitors</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 2 million">
-                  2+ million
-                </dd>
-              </div>
-              <div className="flex flex-col-reverse justify-center">
-                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Government Users</dt>
-                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 1,000">
-                  1,000+
-                </dd>
-              </div>
+              <ImpactStat label="Downloads Served" ariaLabel="over 800 million" value="800+ million" />
+              <ImpactStat label="Pages of Court Data" ariaLabel="over 250 million" value="250+ million" />
+              <ImpactStat label="API Requests Served" ariaLabel="over 100 million" value="100+ million" />
+              <ImpactStat label="Emails Sent" ariaLabel="over 5.4 million" value="5.4+ million" />
+              <ImpactStat label="Monthly Visitors" ariaLabel="over 2 million" value="2+ million" />
+              <ImpactStat label="Government Users" ariaLabel="over 1,000" value="1,000+" />
             </dl>
             <div className="flex justify-center mt-16">
               <PurpleButton size="lg" href="/donate/">

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,57 +37,55 @@ export default function Home({ allPostsData }) {
 
         <HeroImage />
 
-        <MainFullBleedColumn bgClasses="bg-gray-100">
-          <section aria-labelledby="impact-heading">
-            <div className="pt-16 w-full text-center">
-              <HeroHeading tag="h2"><span className="lg:text-7xl" id="impact-heading">Our Impact</span></HeroHeading>
-            </div>
-            <div className="py-16" id="impact">
-              <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-18 text-center">
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">Downloads Served</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 800 million">
-                    800M+
-                  </dd>
-                </div>
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">Pages of Court Data</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 250 million">
-                    250M+
-                  </dd>
-                </div>
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">API Requests Served</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 100 million">
-                    100M+
-                  </dd>
-                </div>
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">Emails Sent</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 5.4 million">
-                    5.4M+
-                  </dd>
-                </div>
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">Monthly Visitors</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 2 million">
-                    2M+
-                  </dd>
-                </div>
-                <div className="flex flex-col-reverse">
-                  <dt className="text-lg font-display text-gray-600 mt-2">Government Users</dt>
-                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 1,000">
-                    1,000+
-                  </dd>
-                </div>
-              </dl>
-              <div className="flex justify-center pt-10">
-                <PurpleButton size="lg" href="/donate/">
-                  Donate Now
-                </PurpleButton>
+        <MainFullBleedColumn aria-labelledby="impact-heading" bgClasses="bg-gray-100">
+          <div className="pt-16 w-full text-center">
+            <HeroHeading id="impact-heading" tag="h2">Our Impact</HeroHeading>
+          </div>
+          <div className="py-16" id="impact">
+            <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-18 text-center">
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Downloads Served</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 800 million">
+                  800+ million
+                </dd>
               </div>
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Pages of Court Data</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 250 million">
+                  250+ million
+                </dd>
+              </div>
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">API Requests Served</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 100 million">
+                  100+ million
+                </dd>
+              </div>
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Emails Sent</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 5.4 million">
+                  5.4+ million
+                </dd>
+              </div>
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Monthly Visitors</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 2 million">
+                  2+ million
+                </dd>
+              </div>
+              <div className="flex flex-col-reverse">
+                <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Government Users</dt>
+                <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 1,000">
+                  1,000+
+                </dd>
+              </div>
+            </dl>
+            <div className="flex justify-center mt-16">
+              <PurpleButton size="lg" href="/donate/">
+                Donate Now
+              </PurpleButton>
             </div>
-          </section>
+          </div>
         </MainFullBleedColumn>
 
         <MainColumn>

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,6 +37,59 @@ export default function Home({ allPostsData }) {
 
         <HeroImage />
 
+        <MainFullBleedColumn bgClasses="bg-gray-100">
+          <section aria-labelledby="impact-heading">
+            <div className="pt-16 w-full text-center">
+              <HeroHeading tag="h2"><span className="lg:text-7xl" id="impact-heading">Our Impact</span></HeroHeading>
+            </div>
+            <div className="py-16" id="impact">
+              <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-18 text-center">
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">Downloads Served</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 800 million">
+                    800M+
+                  </dd>
+                </div>
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">Pages of Court Data</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 250 million">
+                    250M+
+                  </dd>
+                </div>
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">API Requests Served</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 100 million">
+                    100M+
+                  </dd>
+                </div>
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">Emails Sent</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 5.4 million">
+                    5.4M+
+                  </dd>
+                </div>
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">Monthly Visitors</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 2 million">
+                    2M+
+                  </dd>
+                </div>
+                <div className="flex flex-col-reverse">
+                  <dt className="text-lg font-display text-gray-600 mt-2">Government Users</dt>
+                  <dd className="text-3xl md:text-5xl font-bold font-mono text-gray-700" aria-label="over 1,000">
+                    1,000+
+                  </dd>
+                </div>
+              </dl>
+              <div className="flex justify-center pt-10">
+                <PurpleButton size="lg" href="/donate/">
+                  Donate Now
+                </PurpleButton>
+              </div>
+            </div>
+          </section>
+        </MainFullBleedColumn>
+
         <MainColumn>
           <section className="flex flex-wrap items-center pt-8 pb-20" id="recap">
             <div className="w-2/3 sm:w-1/2">

--- a/pages/index.js
+++ b/pages/index.js
@@ -217,7 +217,7 @@ export default function Home({ allPostsData }) {
         <MainFullBleedColumn bgClasses="bg-purple-800">
           <div className="pt-16 pb-24  text-gray-100" id="bots">
             <div className="w-full text-center">
-              <HeroHeadingMono>Case Bots</HeroHeadingMono>
+              <HeroHeadingMono tag="h2">Case Bots</HeroHeadingMono>
             </div>
             <div className="w-full pt-3 pb-5">
               <H3 textColor="text-gray-100">
@@ -293,7 +293,7 @@ export default function Home({ allPostsData }) {
 
           <section className="w-full py-16" id="tools">
             <div className="w-full text-center">
-              <HeroHeading>We Build Tools</HeroHeading>
+              <HeroHeading tag="h2">We Build Tools</HeroHeading>
             </div>
             <div className="w-full pt-3 pb-5 text-gray-700">
               <H3>
@@ -356,7 +356,7 @@ export default function Home({ allPostsData }) {
         <MainFullBleedColumn bgClasses="bg-purple-800">
           <div className="pt-16 pb-24  text-gray-100" id="datasets">
             <div className="w-full text-center">
-              <HeroHeading>We Build Datasets</HeroHeading>
+              <HeroHeading tag="h2">We Build Datasets</HeroHeading>
             </div>
             <div className="w-full pt-3 pb-5">
               <H3 textColor="text-gray-100">

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,9 +59,9 @@ export default function Home({ allPostsData }) {
         </MainFullBleedColumn>
 
         <MainColumn>
-          <section className="flex flex-wrap items-center pt-8 pb-20" id="recap">
+          <section className="flex flex-wrap items-center pt-8 pb-20" id="recap" aria-labelledby="recap-heading">
             <div className="w-2/3 sm:w-1/2">
-              <H2>The RECAP Suite helps you liberate and work with court documents.</H2>
+              <H2 id="recap-heading">The RECAP Suite helps you liberate and work with court documents.</H2>
             </div>
             <div className="hidden sm:flex justify-end sm:w-1/2 pl-8 pt-5">
               <div className="relative w-full max-w-[350px] aspect-[350/207]">
@@ -130,10 +130,10 @@ export default function Home({ allPostsData }) {
           </section>
         </MainColumn>
 
-        <MainFullBleedColumn id="courtlistener" bgClasses="bg-gradient-to-b from-gray-200 to-white">
+        <MainFullBleedColumn id="courtlistener" aria-labelledby="courtlistener-heading" bgClasses="bg-gradient-to-b from-gray-200 to-white">
           <div className="flex flex-wrap py-16">
             <div className="w-2/3 lg:w-1/2 pb-4">
-              <H2>
+              <H2 id="courtlistener-heading">
                 <Link href="https://www.courtlistener.com/" className="underline">
                   CourtListener
                 </Link>{' '}
@@ -235,10 +235,10 @@ export default function Home({ allPostsData }) {
           </div>
         </MainFullBleedColumn>
 
-        <MainFullBleedColumn bgClasses="bg-purple-800">
+        <MainFullBleedColumn aria-labelledby="bots-heading" bgClasses="bg-purple-800">
           <div className="pt-16 pb-24  text-gray-100" id="bots">
             <div className="w-full text-center">
-              <HeroHeadingMono tag="h2">Case Bots</HeroHeadingMono>
+              <HeroHeadingMono id="bots-heading" tag="h2">Case Bots</HeroHeadingMono>
             </div>
             <div className="w-full pt-3 pb-5">
               <H3 textColor="text-gray-100">
@@ -290,6 +290,7 @@ export default function Home({ allPostsData }) {
           <section
             className="grid grid-cols-1 sm:grid-cols-2 gap-6 sm:gap-8 py-8 md:py-16"
             id="advocacy"
+            aria-labelledby="advocacy-heading"
           >
             <div className="pt-10 sm:pt-20 justify-center flex">
               <div className="relative w-full max-w-[450px] aspect-[450/265]">
@@ -302,7 +303,7 @@ export default function Home({ allPostsData }) {
               </div>
             </div>
             <div className="pt-8 sm:pt-28 text-center">
-              <H2>Legal Advocacy</H2>
+              <H2 id="advocacy-heading">Legal Advocacy</H2>
               <p className="text-left pt-5">
                 We work to make the legal system better by changing it from within. Among our
                 initiatives are legislation to make PACER free, early research into a FOIA-like law
@@ -312,9 +313,9 @@ export default function Home({ allPostsData }) {
             </div>
           </section>
 
-          <section className="w-full py-16" id="tools">
+          <section className="w-full py-16" id="tools" aria-labelledby="tools-heading">
             <div className="w-full text-center">
-              <HeroHeading tag="h2">We Build Tools</HeroHeading>
+              <HeroHeading id="tools-heading" tag="h2">We Build Tools</HeroHeading>
             </div>
             <div className="w-full pt-3 pb-5 text-gray-700">
               <H3>
@@ -374,10 +375,10 @@ export default function Home({ allPostsData }) {
           </section>
         </MainColumn>
 
-        <MainFullBleedColumn bgClasses="bg-purple-800">
+        <MainFullBleedColumn aria-labelledby="datasets-heading" bgClasses="bg-purple-800">
           <div className="pt-16 pb-24  text-gray-100" id="datasets">
             <div className="w-full text-center">
-              <HeroHeading tag="h2">We Build Datasets</HeroHeading>
+              <HeroHeading id="datasets-heading" tag="h2">We Build Datasets</HeroHeading>
             </div>
             <div className="w-full pt-3 pb-5">
               <H3 textColor="text-gray-100">
@@ -441,9 +442,9 @@ export default function Home({ allPostsData }) {
         </MainFullBleedColumn>
 
         <MainColumn>
-          <section className="w-full py-16" id="testimonials">
+          <section className="w-full py-16" id="testimonials" aria-labelledby="testimonials-heading">
             <div className="text-center">
-              <H2>You're in Good Company</H2>
+              <H2 id="testimonials-heading">You're in Good Company</H2>
               <div className="w-3/4 pt-5 m-auto">
                 <H3>
                   When you need legal data, we can help. We work with journalists, researchers, and
@@ -462,10 +463,10 @@ export default function Home({ allPostsData }) {
           </section>
         </MainColumn>
 
-        <MainFullBleedColumn bgClasses="bg-smile">
+        <MainFullBleedColumn aria-labelledby="support-heading" bgClasses="bg-smile">
           <div className="pt-16 pb-24 text-gray-100" id="support-us">
             <div className="px-10 text-center">
-              <H2>Like what you see? Please support our work.</H2>
+              <H2 id="support-heading">Like what you see? Please support our work.</H2>
             </div>
             <div className="flex justify-center gap-8 pt-8">
               <Button href="/become-a-sponsor/" extraClasses="bg-white text-gray-800">

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,37 +43,37 @@ export default function Home({ allPostsData }) {
           </div>
           <div className="py-16" id="impact">
             <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-18 text-center">
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Downloads Served</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 800 million">
                   800+ million
                 </dd>
               </div>
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Pages of Court Data</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 250 million">
                   250+ million
                 </dd>
               </div>
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">API Requests Served</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 100 million">
                   100+ million
                 </dd>
               </div>
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Emails Sent</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 5.4 million">
                   5.4+ million
                 </dd>
               </div>
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Monthly Visitors</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 2 million">
                   2+ million
                 </dd>
               </div>
-              <div className="flex flex-col-reverse">
+              <div className="flex flex-col-reverse justify-center">
                 <dt className="text-lg font-mono font-bold text-gray-600 mt-2">Government Users</dt>
                 <dd className="text-3xl md:text-5xl font-light font-display text-gray-700" aria-label="over 1,000">
                   1,000+


### PR DESCRIPTION
Closes #409 

### Summary

- Add "Our Impact" stats section to the homepage between the hero and RECAP sections, showcasing key 2025 metrics with a donate CTA
- Add `tag` prop to `HeroHeading`/`HeroHeadingMono` so heading level can be overridden (needed for proper heading hierarchy)
- Add `...props` spread to `HeroHeading` and `MainFullBleedColumn` for flexibility

### Accessibility

- Semantic `dl`/`dt`/`dd` for stats, with `flex-col-reverse` for visual order
- `aria-labels` for abbreviated numbers (e.g. "800+ million")
- Section landmark with `aria-labelledby` + proper `h2` heading level
- Fixed existing `HeroHeading`/`HeroHeadingMono` usages that were rendering as `h1` instead of `h2`


### Screenshots

<details>
<summary>Desktop</summary>

<img width="1000" alt="Homepage screenshot desktop" src="https://github.com/user-attachments/assets/721dfd6a-7543-4acf-98a3-8242eb587d8b" />

</details>

<details>
<summary>Mobile</summary>

<img width="350" alt="Homepage screenshot mobile" src="https://github.com/user-attachments/assets/e4a2cd12-c158-457b-a5c2-f7ada7aff468" />

</details>

