### PR TITLE
Fix link path for RFP document

### DIFF
--- a/posts/2026/03/31/litigant-portal-court-cohort-rfp.mdx
+++ b/posts/2026/03/31/litigant-portal-court-cohort-rfp.mdx
@@ -41,7 +41,7 @@ We are not looking for courts with finished content libraries, large IT budgets,
 
 Letters of interest are due **May 1, 2026**. We are asking for no more than two pages. Selected applicants will be invited to structured conversations with the Free Law Project team in May, and the cohort will be announced June 1. Pilot launches in September 2026.
 
-The full RFP is available [here](/public/pdf/Litigant%20Portal_RFP_2026.pdf). If you work with a court that should be part of this conversation, I would welcome an introduction.
+The full RFP is available [here](/pdf/Litigant%20Portal_RFP_2026.pdf). If you work with a court that should be part of this conversation, I would welcome an introduction.
 
 Courts that are uncertain whether they are a good fit are encouraged to reach out before submitting. We would rather have that conversation early.
 


### PR DESCRIPTION
Removed `public/` from the path for linked document in blog post.