### PR TITLE
Add semantic search to Librarians Guide

### DIFF
--- a/posts/librarians.mdx
+++ b/posts/librarians.mdx
@@ -45,7 +45,7 @@ type: page
 
 - **Semantic Search** lets you search case law using natural language. Instead of exact keyword matching, it finds relevant opinions based on the meaning of your query. Hybrid search lets you combine natural language with specific keywords by wrapping them in quotation marks.
 
-  [Blog](/2026/05/01/semantic-search-on-courtlistener)
+  [Blog](/2026/04/30/semantic-search-on-courtlistener)
 
 ## RECAP Suite
 

--- a/posts/librarians.mdx
+++ b/posts/librarians.mdx
@@ -45,7 +45,7 @@ type: page
 
 - **Semantic Search** lets you search case law using natural language. Instead of exact keyword matching, it finds relevant opinions based on the meaning of your query. Hybrid search lets you combine natural language with specific keywords by wrapping them in quotation marks.
 
-  [Blog](/2026/04/30/semantic-search-on-courtlistener)
+  [Blog](/2026/05/04/semantic-search-on-courtlistener)
 
 ## RECAP Suite
 

--- a/posts/librarians.mdx
+++ b/posts/librarians.mdx
@@ -43,6 +43,10 @@ type: page
 
   [Blog](/2022/03/17/summarizing-important-cases/)
 
+- **Semantic Search** lets you search case law using natural language. Instead of exact keyword matching, it finds relevant opinions based on the meaning of your query. Hybrid search lets you combine natural language with specific keywords by wrapping them in quotation marks.
+
+  [Blog](/2026/05/01/semantic-search-on-courtlistener)
+
 ## RECAP Suite
 
 <p className="lead">The RECAP Archive in CourtListener is the biggest open collection of federal court data on the internet.</p>


### PR DESCRIPTION
## Fixes

Fixes: #457

## Summary

Adds a bullet point under the Case Law section of the Librarians Guide describing semantic search and hybrid search capabilities, with a link to the launch blog post.