### PR TITLE
feat(membership): Adds API access tiers to member benefits

### DIFF
--- a/posts/membership.mdx
+++ b/posts/membership.mdx
@@ -74,6 +74,18 @@ Every membership directly supports our nonprofit mission to provide free and ope
         <th
           scope="row"
           className="sticky left-0 border-r border-gray-200 z-20 bg-white pl-4 pr-3 md:pr-4 py-5 text-sm font-medium text-gray-700
+           border-b border-gray-100">[API Access][api]</th>
+        <td className="px-6 py-5 border-b border-gray-100">5/minute<br/>50/hour<br/>125/day<br/>Community support</td>
+        <td className="px-6 py-5 border-b border-gray-100">10/minute<br/>75/hour<br/>300/day<br/>Community support</td>
+        <td className="px-6 py-5 border-b border-gray-100">15/minute<br/>150/hour<br/>600/day<br/>Community support</td>
+        <td className="px-6 py-5 border-b border-gray-100">20/minute<br/>250/hour<br/>1,000/day<br/>Private support</td>
+        <td className="px-6 py-5 border-b border-gray-100">25/minute<br/>300/hour<br/>1,400/day<br/>Private support</td>
+      </tr>
+
+      <tr>
+        <th
+          scope="row"
+          className="sticky left-0 border-r border-gray-200 z-20 bg-white pl-4 pr-3 md:pr-4 py-5 text-sm font-medium text-gray-700
            border-b border-gray-100">[Docket Alerts][docket-alerts]</th>
         <td className="px-6 py-5 border-b border-gray-100">5*</td>
         <td className="px-6 py-5 border-b border-gray-100">Unlimited</td>
@@ -186,6 +198,7 @@ Already a member? <a href="https://donate.free.law">Upgrade Your Membership</a>
 [pray-and-pay]: https://www.courtlistener.com/help/pray-and-pay/
 [stickers]: https://free.law/stickers/
 [shop]: https://shop.printyourcause.com/campaigns/free-law-project---for-sales
+[api]: https://www.courtlistener.com/help/api/
 
 ## Group Membership Tiers & Benefits
 


### PR DESCRIPTION
Closes https://github.com/freelawproject/internal/issues/926

### Summary

- Adds an **API Access** row to the Individual Member Tiers table on `/membership/`, covering rate limits (per minute, hour, day) and support type for the Free tier and Tiers 1–4.
- Registers a `[api]` reference link pointing to the CourtListener API help docs.

<img width="1922" height="1658" alt="image" src="https://github.com/user-attachments/assets/35926553-761e-4f41-91f2-699ec8b6c98c" />

### Related pages reviewed

I checked other content pages that mention API access or membership benefits (`recap.mdx`, `librarians.mdx`, `datasets.mdx`, `donate.mdx`, `data-consulting.mdx`, `projects/*.mdx`). Most only link out to the API docs or `/membership/`, so they pick up the new info automatically. No edits needed there.

### Open questions

1. **Should `posts/startups.mdx` mention the new Commercial tier?**
   The "How the Money Works" section currently says *"Prices start at free and go up from there"* and pitches licensing for for-profits. The new Commercial tier ($400+/month, 75/min and up) could be a useful entry point to mention there for startups that just need higher API limits without a full custom deal. Happy to add a line if it makes sense, but didn't want to expand scope without asking.

2. **Is the API Access row in the right spot in the table?**
 