### PR TITLE
fix(redirects): 301 stray /blog/ post URLs to canonical paths

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
+[[redirects]]
+    from = "/blog/:year/:month/:day/:slug/*"
+    to = "/:year/:month/:day/:slug/"
+    status = 301
+    force = true
+
 [[headers]]
     for = "/*"
     [headers.values]


### PR DESCRIPTION
## Summary

- Adds a Netlify 301 redirect for `/blog/:year/:month/:day/:slug/*` → `/:year/:month/:day/:slug/`
- Handles any externally linked post that accidentally uses the `/blog/` prefix (the canonical URL has no `/blog/` segment for individual posts — only the index lives at `/blog/`)
- 301 + `force = true` so ranking signals transfer and the rule isn't shadowed by a static file
- Generalized via splat so it covers all date-prefixed posts, not just the Claude/MCP announcement (supersedes #feat-add-redirection-for-mcp-post which only handled one URL)

## Test plan

- [ ] Confirm Netlify deploy preview applies the redirect: `/blog/2026/05/12/courtlistener-is-now-available-inside-claude/` → `/2026/05/12/courtlistener-is-now-available-inside-claude/` with a 301
- [ ] Confirm `/blog/` (blog index) still resolves normally and is not redirected
- [ ] Spot-check another older post via the same `/blog/YYYY/...` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)