### PR TITLE
Add information disclosure vuln

### DIFF
--- a/posts/vulnerability-disclosure-policy.mdx
+++ b/posts/vulnerability-disclosure-policy.mdx
@@ -123,6 +123,7 @@ The complete history of this document, including unofficial edits, can be found 
 
 We thank the following individuals for their assistance reporting and fixing vulnerabilities in our systems:
 
+ - @recap.email API information disclosure vulnerability via shared credential usage (<a href="https://github.com/algorythmic">Grisha Levit</a>, 2026-05-22) <Tag name="CourtListener" href="https://github.com/freelawproject/courtlistener/pull/7385" />
  - Hyperlink injection into welcome emails (Vaibhav Jain, 2024-09-27) <Tag name="CourtListener" href="https://github.com/freelawproject/courtlistener/pull/4701"/>
  - Improper website's cache control headers (<a href={"https://www.linkedin.com/in/parth-narula-86283821a"}>Parth Narula</a>, 2024-09-15) <Tag name="Bots.law" href="https://github.com/freelawproject/bigcases2/issues/599"/>
  - Text injection in registration success page (<a href={"https://www.linkedin.com/in/parth-narula-86283821a"}>Parth Narula</a>, 2024-09-15) <Tag name="CourtListener" href="https://github.com/freelawproject/courtlistener/issues/4466"/><Tag name="Bots.law" href="https://github.com/freelawproject/bigcases2/issues/601"/>


### PR DESCRIPTION
We locked down the @recap.email API, this notes the vulnerability publicly.