### PR TITLE
feat(github): add PR template with AI disclosure section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Fixes
+<!-- What issues does this fix? Use this syntax to auto-close the issue: -->
+<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
+<!-- E.g.: "Fixes: #XYZ" -->
+This fixes...
+
+## Summary
+<!-- What does this change, how did you approach it, and are there any gotchas or compromises? -->
+This PR...
+
+## Screenshots (optional)
+<!-- If this changes how the site looks, please include screenshots or videos showing the change. -->
+
+## AI Disclosure
+<!-- Please check the one box that applies. -->
+- [ ] No AI tools were used to create the content of this PR.
+- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
+
+<!-- Thank you for contributing and filling out this form! -->


### PR DESCRIPTION
## Fixes
Fixes: #498

## Summary
This PR adds a pull request template for this repo, modeled loosely on courtlistener's but leaner. Beyond the usual Fixes/Summary/Screenshots sections, it adds an **AI Disclosure** section requiring contributors to assert that, if any part of the PR was created with the help of an AI tool, they have carefully reviewed all of its content and take full responsibility for it.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)