### PR TITLE
feat(volunteer): ask volunteers to refer to the volunteer AI policy

### DIFF
--- a/posts/volunteer.mdx
+++ b/posts/volunteer.mdx
@@ -5,6 +5,8 @@ type: page
 
 <p className="lead">We appreciate your interest in volunteering to support our work! There are a few ways to contribute your time.</p>
 
+When volunteering with Free Law Project, please refer to our [AI policies for volunteers](https://wiki.free.law/c/ai-policies-resources/policies/artificial-intelligence-policies-for-volunteers-working-with-free-law-project) for guidance on the use of AI tools in your contributions.
+
 ## As a User
 
 If you use CourtListener, then your feedback is invaluable. Please [let us know][c] what bugs you and what you love. 


### PR DESCRIPTION
## Fixes
Fixes: #497

## Summary
This PR adds a sentence to the [volunteer page](https://free.law/volunteer/), right under the lead paragraph, asking volunteers to refer to the [AI policies for volunteers](https://wiki.free.law/c/ai-policies-resources/policies/artificial-intelligence-policies-for-volunteers-working-with-free-law-project) when volunteering with Free Law Project.

Note: the linked wiki policy page is not publicly accessible yet; its permissions will be updated separately.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)