### PR TITLE
Revert(membership): End doubled API access promotion

### DIFF
--- a/posts/membership.mdx
+++ b/posts/membership.mdx
@@ -6,12 +6,6 @@ excerpt: "Unlock unlimited docket alerts, API access, and powerful case law sear
 
 <p className="lead">Membership with Free Law Project gives you more than just access to advanced research tools—it connects you to a movement dedicated to breaking down legal paywalls. From real-time alerts on the cases that matter to enhanced API access, and smarter, faster case law searches, your membership powers both your work and our mission to make the law open and accessible to everyone.</p>
 
-<div className="rounded-lg border-2 border-purple-400 bg-purple-100 px-6 py-5 my-8">
-  <p className="my-0 text-sm font-bold uppercase tracking-wide text-purple-700">Limited-Time Promotion</p>
-  <p className="mt-2 mb-0 text-gray-800">Now through <strong>August 6, 2026</strong>, we're <strong>doubling the API access</strong> included with the free tier and every membership tier below (except EDU memberships, which already include elevated access), so more people can try AI&#8209;powered legal research with <a href="https://wiki.free.law/c/courtlistener/help/api/mcp/model-context-protocol-mcp-server-for-agentic-access">our MCP connector</a>. Join during the promotion and research at twice the speed.</p>
-  <p className="mt-2 mb-0"><a href="/2026/07/07/double-api-access-to-courtlistener/">Read the announcement</a></p>
-</div>
-
 ## Membership
 
 Free Law Project offers individual, group, EDU, and LSO memberships so everyone can strengthen access to legal information while powering their own research.
@@ -153,7 +147,7 @@ Every membership directly supports our nonprofit mission to provide free and ope
         <th
           scope="row"
           className="sticky left-0 border-r border-gray-200 z-20 bg-white pl-4 pr-3 md:pr-4 py-5 text-sm font-medium text-gray-700
-           border-b border-gray-100">[API Access][api]<sup>2, 3</sup><br/><span className="mt-1 inline-block rounded bg-purple-800 px-2 py-0.5 text-xs font-bold text-white">2&times; until Aug&nbsp;6</span></th>
+           border-b border-gray-100">[API Access][api]<sup>2</sup></th>
         <td className="px-6 py-5 border-b border-gray-100">5/minute<br/>50/hour<br/>125/day<br/>Community support</td>
         <td className="px-6 py-5 border-b border-gray-100">10/minute<br/>75/hour<br/>300/day<br/>Community support</td>
         <td className="px-6 py-5 border-b border-gray-100">15/minute<br/>150/hour<br/>600/day<br/>Community support</td>
@@ -176,7 +170,7 @@ Every membership directly supports our nonprofit mission to provide free and ope
   </table>
   <p><sup>1</sup> Install the [RECAP extension][r] to automatically get 10 bonus alerts in the free tier!</p>
   <p><sup>2</sup> Membership API access is for small law firms, small governmental bodies, legal service organizations, small media outlets, academics, and organizations that are pre-revenue and pre-funding. It is not for large or funded organizations. [See details][mem-api-details].</p>
-  <p><sup>3</sup> Now through August 6, 2026, these rates are doubled for the free tier and every membership tier shown here as part of [our AI connector promotion][promo]. EDU memberships already include elevated access and are not doubled.</p>  <p id="scroll-hint" className="sr-only">This area scrolls horizontally to reveal additional membership tiers.</p>
+  <p id="scroll-hint" className="sr-only">This area scrolls horizontally to reveal additional membership tiers.</p>
   </div>
 </div>
 </div>
@@ -196,7 +190,6 @@ Every membership directly supports our nonprofit mission to provide free and ope
 [stickers]: /stickers/
 [shop]: https://shop.printyourcause.com/campaigns/free-law-project---for-sales
 [mem-api-details]: /membership/allowed-api-usage/
-[promo]: /2026/07/07/double-api-access-to-courtlistener/
 
 
 ## Group Membership Tiers & Benefits


### PR DESCRIPTION
The 30-day doubled-API-access promotion (July 7 – August 6, 2026) ended
yesterday. This reverts the membership page changes from #483 that
highlighted it — the promo callout, the "2× until Aug 6" badge on the API
Access row, and the related footnote/link.

The announcement blog post itself is left in place as a dated historical
record.

This reverts commit ca2c95c0e38fdef3dfb2a190c359d6937e5b98c3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)